### PR TITLE
feat: Pre-commit hook with basic config for flake8 and black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 100
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+    - repo: https://github.com/ambv/black
+      rev: stable
+      hooks:
+          - id: black
+            language_version: python3.7
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.7.9
+      hooks:
+          - id: flake8

--- a/.toml
+++ b/.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 100
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''


### PR DESCRIPTION
closes #14 


Introduced flake8 and black as pre-commit hooks to run before a commit happens. Tests are not included due to speed and dependeny reasons. We can think about it of adding it but I think it is okay if they run in the pipeline.

See this issue https://github.com/pre-commit/pre-commit-hooks/issues/291