### PR TITLE
add other class id to snorkel

### DIFF
--- a/knodle/trainer/snorkel/utils.py
+++ b/knodle/trainer/snorkel/utils.py
@@ -1,5 +1,10 @@
+from typing import Tuple
+
 import numpy as np
 import scipy.sparse as sp
+from torch.utils.data import TensorDataset
+
+from knodle.transformation.filter import filter_tensor_dataset_by_indices
 
 
 def z_t_matrix_to_snorkel_matrix(rule_matches_z: np.ndarray, mapping_rules_labels_t: np.ndarray) -> np.ndarray:
@@ -14,3 +19,51 @@ def z_t_matrix_to_snorkel_matrix(rule_matches_z: np.ndarray, mapping_rules_label
         snorkel_matrix[i, non_zero_idx] = z_to_t[non_zero_idx]
 
     return snorkel_matrix
+
+def prepare_empty_rule_matches(rule_matches_z, filter_non_labelled, model_input_x
+) -> Tuple[np.ndarray, np.ndarray, TensorDataset]:
+    """
+    Remove empty rows in rule matches for LabelModel. If filtering is configured, the corresponding entries
+    in the model input are filtered out as well.
+    Args:
+        rule_matches_z:
+        filter_non_labelled: if rows with no rule matches should be filtered.
+        model_input_x:
+    Returns:
+        boolean mask indicating non-empty rows,
+        filtered rule matches,
+        and eventually filtered model input
+    """
+    # find empty rows of the rule matches
+    non_zero_mask = rule_matches_z.sum(axis=1) != 0
+    non_zero_indices = np.where(non_zero_mask)[0]
+
+    # exclude empty rows from LabelModel input
+    rule_matches_z = rule_matches_z[non_zero_indices]
+
+    if filter_non_labelled:
+        # filter out respective input irrevocably from all data
+        model_input_x = filter_tensor_dataset_by_indices(dataset=model_input_x, filter_ids=non_zero_indices)
+
+    return non_zero_mask, rule_matches_z, model_input_x
+
+def add_labels_for_empty_examples(label_probs_gen, non_zero_mask, output_classes, other_class_id
+) -> np.ndarray:
+    """
+    Args:
+        label_probs_gen: labels generated for the non-empty rows
+        non_zero_mask:  boolean mask indicating which examples get the generated labels
+        output_classes: number of output classes, with respect to the other_class
+        other_class_id: id of the class for empty rows
+    Returns: distribution of labels for both empty and non-empty rows (#examples x #classes)
+    """
+    # make dummy label distibutions for all of the examples
+    # number of output classes is eventually t.shape[1]+1, if other class id should be added
+    label_probs = np.zeros((non_zero_mask.shape[0], output_classes))
+
+    # fill labels of the generative model
+    label_probs[non_zero_mask, :label_probs_gen.shape[1]] = label_probs_gen
+
+    # assign full probability to other class for empty rows
+    label_probs[~non_zero_mask, other_class_id] = 1
+    return label_probs

--- a/knodle/transformation/filter.py
+++ b/knodle/transformation/filter.py
@@ -9,7 +9,7 @@ def filter_tensor_dataset_by_indices(dataset: TensorDataset, filter_ids: Union[n
 
     Args:
         dataset: TensorDataset with a list of tensors, each having first dimension N
-        filter_ids: A list of K indices, K <= N
+        filter_ids: A list of K indices to be kept, K <= N
 
     Returns: TensorDataset with filtered indices
     """

--- a/tests/trainer/snorkel/test_utils.py
+++ b/tests/trainer/snorkel/test_utils.py
@@ -1,5 +1,12 @@
 import numpy as np
-from knodle.trainer.snorkel.utils import z_t_matrix_to_snorkel_matrix
+
+import torch
+from torch.utils.data import TensorDataset
+from knodle.trainer.snorkel.utils import (
+    z_t_matrix_to_snorkel_matrix,
+    prepare_empty_rule_matches,
+    add_labels_for_empty_examples
+)
 
 
 def test_z_t_matrix_to_snorkel_matrix():
@@ -22,3 +29,77 @@ def test_z_t_matrix_to_snorkel_matrix():
 
     snorkel_test = z_t_matrix_to_snorkel_matrix(z, t)
     np.testing.assert_equal(snorkel_gold, snorkel_test)
+
+
+def test_label_model_data():
+    num_samples = 5
+    num_features = 16
+    num_rules = 6
+
+    x_np = np.ones((num_samples, num_features)).astype(np.float32)
+    x_tensor = torch.from_numpy(x_np)
+    model_input_x = TensorDataset(x_tensor)
+
+    rule_matches_z = np.ones((num_samples, num_rules))
+    rule_matches_z[[1, 4]] = 0
+
+    # test with filtering
+    non_zero_mask, out_rule_matches_z, out_model_input_x = prepare_empty_rule_matches(
+        rule_matches_z=rule_matches_z,
+        model_input_x=model_input_x,
+        filter_non_labelled=True
+    )
+
+    expected_mask = np.array([True, False, True, True, False])
+    expected_rule_matches = np.ones((3, num_rules))
+
+    np.testing.assert_equal(non_zero_mask, expected_mask)
+    np.testing.assert_equal(out_rule_matches_z, expected_rule_matches)
+    assert len(out_model_input_x) == 3
+
+    # test without filtering
+    non_zero_mask, out_rule_matches_z, out_model_input_x = prepare_empty_rule_matches(
+        rule_matches_z=rule_matches_z,
+        model_input_x=model_input_x,
+        filter_non_labelled=False
+    )
+
+    expected_mask = np.array([True, False, True, True, False])
+    expected_rule_matches = np.ones((3, num_rules))
+
+    np.testing.assert_equal(non_zero_mask, expected_mask)
+    np.testing.assert_equal(out_rule_matches_z, expected_rule_matches)
+    assert len(out_model_input_x) == 5
+
+def test_other_class_labels():
+    label_probs_gen = np.array([
+        [0.3, 0.6, 0.0, 0.1],
+        [0.2, 0.2, 0.2, 0.4],
+        [1.0, 0.0, 0.0, 0.0]
+    ])
+    output_classes = 5
+    other_class_id = 4
+
+    # test without empty rows
+    non_zero_mask = np.array([True, True, True])
+    expected_probs = np.array([
+        [0.3, 0.6, 0.0, 0.1, 0.0],
+        [0.2, 0.2, 0.2, 0.4, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0]
+    ])
+    label_probs = add_labels_for_empty_examples(label_probs_gen, non_zero_mask, output_classes, other_class_id)
+
+    np.testing.assert_equal(label_probs, expected_probs)
+
+    # test with empty rows
+    non_zero_mask = np.array([True, False, False, True, True])
+    expected_probs = np.array([
+        [0.3, 0.6, 0.0, 0.1, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.2, 0.2, 0.2, 0.4, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0]
+    ])
+    label_probs = add_labels_for_empty_examples(label_probs_gen, non_zero_mask, output_classes, other_class_id)
+
+    np.testing.assert_equal(label_probs, expected_probs)


### PR DESCRIPTION
Before:
- Negative samples are always filtered out
- Setting filter-non-labelled to False had no effect

After:
- LabelModel generates labels for the "positive" examples with rule matches
- Negative examples are added directly to the final training data with a respective other_class_id
 