### PR TITLE
Feature/276 include check for other class

### DIFF
--- a/knodle/trainer/auto_config.py
+++ b/knodle/trainer/auto_config.py
@@ -13,7 +13,7 @@ class AutoConfig:
     """ Internal registry for available trainers """
 
     def __init__(self, name, **kwargs):
-        self.config = self.create_trainer(name, **kwargs)
+        self.config = self.create_config(name, **kwargs)
 
     @classmethod
     def create_config(cls, name: str, **kwargs) -> TrainerConfig:

--- a/knodle/trainer/baseline/majority.py
+++ b/knodle/trainer/baseline/majority.py
@@ -24,20 +24,10 @@ class MajorityVoteTrainer(BaseTrainer):
         A simple majority vote is used for this purpose.
     """
 
-    def __init__(
-            self,
-            model: nn.Module,
-            mapping_rules_labels_t: np.ndarray,
-            model_input_x: TensorDataset,
-            rule_matches_z: np.ndarray,
-            trainer_config: MajorityConfig = None,
-            **kwargs
-    ):
-        if trainer_config is None:
-            trainer_config = MajorityConfig(optimizer=SGD, lr=0.001)
-        super().__init__(
-            model, mapping_rules_labels_t, model_input_x, rule_matches_z, trainer_config=trainer_config, **kwargs
-        )
+    def __init__(self, **kwargs):
+        if kwargs.get("trainer_config") is None:
+            kwargs["trainer_config"] = MajorityConfig(optimizer=SGD, lr=0.001)
+        super().__init__(**kwargs)
 
     def train(
             self,

--- a/knodle/trainer/trainer.py
+++ b/knodle/trainer/trainer.py
@@ -19,8 +19,9 @@ from knodle.evaluation.other_class_metrics import classification_report_other_cl
 from knodle.transformation.torch_input import input_labels_to_tensordataset, dataset_to_numpy_input
 from knodle.evaluation.plotting import draw_loss_accuracy_plot
 
-from knodle.trainer.config import BaseTrainerConfig
+from knodle.trainer.config import TrainerConfig, BaseTrainerConfig
 from knodle.trainer.utils.utils import log_section, accuracy_of_probs
+from knodle.trainer.utils.checks import check_other_class_id
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class Trainer(ABC):
             rule_matches_z: np.ndarray,
             dev_model_input_x: TensorDataset = None,
             dev_gold_labels_y: TensorDataset = None,
-            trainer_config: BaseTrainerConfig = None,
+            trainer_config: TrainerConfig = None,
     ):
         """
         Constructor for each Trainer.
@@ -53,7 +54,7 @@ class Trainer(ABC):
         self.dev_gold_labels_y = dev_gold_labels_y
 
         if trainer_config is None:
-            self.trainer_config = BaseTrainerConfig(model)
+            self.trainer_config = TrainerConfig(model)
         else:
             self.trainer_config = trainer_config
 
@@ -78,6 +79,13 @@ class Trainer(ABC):
 
 
 class BaseTrainer(Trainer):
+
+    def __init__(self, **kwargs):
+        if kwargs.get("trainer_config", None) is None:
+            kwargs["trainer_config"] = BaseTrainerConfig()
+        super().__init__(**kwargs)
+
+        check_other_class_id(self.trainer_config, self.mapping_rules_labels_t)
 
     def _load_train_params(
             self,

--- a/knodle/trainer/trainer.py
+++ b/knodle/trainer/trainer.py
@@ -80,10 +80,16 @@ class Trainer(ABC):
 
 class BaseTrainer(Trainer):
 
-    def __init__(self, **kwargs):
+    def __init__(
+            self,
+            model: Module,
+            mapping_rules_labels_t: np.ndarray,
+            model_input_x: TensorDataset,
+            rule_matches_z: np.ndarray,
+            **kwargs):
         if kwargs.get("trainer_config", None) is None:
             kwargs["trainer_config"] = BaseTrainerConfig()
-        super().__init__(**kwargs)
+        super().__init__(model, mapping_rules_labels_t, model_input_x, rule_matches_z, **kwargs)
 
         check_other_class_id(self.trainer_config, self.mapping_rules_labels_t)
 


### PR DESCRIPTION
closes #276 

The PR 
1. brings back the BaseTrainer class __init__ function to perform the relevant other class id checks.
2. adjusts the child MajorityVoteTrainer __init__ 
3. changes the default config of Trainer to be TrainerConfig instead of BaseTrainerConfig
4. additionally fixes the AutoConfig create_config call